### PR TITLE
Updated organisation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Installation instructions for the Rust compiler can be found here: https://www.r
 Once the Rust compiler is installed:
 
 ```
-$ git clone https://github.com/CLIMB-COVID/maptide.git
+$ git clone https://github.com/CLIMB-TRE/maptide.git
 $ cd maptide/
 $ python -m venv .venv
 $ source .venv/bin/activate
-$ pip install --upgrade pip
 $ pip install .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 maptide = "maptide.cli:run"
 
 [project.urls]
-repository = "https://github.com/CLIMB-COVID/maptide"
+repository = "https://github.com/CLIMB-TRE/maptide"
 
 [tool.maturin]
 python-source = "python"


### PR DESCRIPTION
- Updated organisation details as the repository was transferred from `CLIMB-COVID` to `CLIMB-TRE`.