### PR TITLE
No args displays `--help`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
           python -m pip install .
       - name: Test CLI
         run: |
+          maptide
           maptide --help

--- a/python/maptide/cli.py
+++ b/python/maptide/cli.py
@@ -101,7 +101,7 @@ def run():
         help="Number of decimal places to display (default: %(default)s)",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(None if sys.argv[1:] else ['-h'])
 
     columns = [
         "chrom",


### PR DESCRIPTION
- CLI with no arguments now displays a help message, rather than an error for the required `bam` argument.